### PR TITLE
add_executable() tided up; removed deprecated

### DIFF
--- a/bot/CMakeLists.txt
+++ b/bot/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(include)
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3")
 
-file(GLOB_RECURSE SRC "*.hpp" "*.cpp")
+file(GLOB_RECURSE SRC "*.cpp")
 add_executable(template_bot ${SRC})
 
 find_library(cpp_vk_lib HINTS "../cpp_vk_lib")

--- a/bot/src/main.cpp
+++ b/bot/src/main.cpp
@@ -5,7 +5,6 @@
 #include "cpp_vk_lib/vk/config/config.hpp"
 #include "cpp_vk_lib/vk/long_poll/long_poll.hpp"
 #include "cpp_vk_lib/runtime/setup_logger.hpp"
-#include "cpp_vk_lib/runtime/signal_handlers.hpp"
 
 #include "spdlog/spdlog.h"
 
@@ -20,7 +19,6 @@ int main(int argc, char* argv[])
     using namespace bot;
     vk::config::load(argv[1]);
     runtime::setup_logger(spdlog::level::level_enum::trace);
-    runtime::setup_signal_handlers();
     spdlog::info("workers: {}", vk::config::num_workers());
 
     bot::message_handler msg_handler;


### PR DESCRIPTION
1) CMAKE: Remove header files from add_executable()
2) BOT: Remove deprecated signal handler